### PR TITLE
Add GSettings schema overrides for i3-GNOME-Flashback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,16 @@ install:
 	$(INSTALL) -m 0644 -D files/i3-gnome-flashback.session $(PREFIX)/share/gnome-session/sessions/i3-gnome-flashback.session
 	$(INSTALL) -m 0755 -D files/i3-gnome-flashback-session $(PREFIX)/bin/i3-gnome-flashback-session
 	$(INSTALL) -m 0755 -D files/i3-gnome-flashback $(PREFIX)/bin/i3-gnome-flashback
+	$(INSTALL) -m 0644 -D files/i3-gnome-flashback.gschema.override $(PREFIX)/share/glib-2.0/schemas/01_i3-gnome-flashback.gschema.override
+	glib-compile-schemas $(PREFIX)/share/glib-2.0/schemas/
 
 uninstall:
 	rm -f $(PREFIX)/bin/i3-gnome-flashback \
 	      $(PREFIX)/bin/i3-gnome-flashback-session \
 	      $(PREFIX)/share/gnome-session/sessions/i3-gnome-flashback.session \
 	      $(PREFIX)/share/applications/i3-gnome-flashback.desktop \
-	      $(PREFIX)/share/xsessions/i3-gnome-flashback-session.desktop
+	      $(PREFIX)/share/xsessions/i3-gnome-flashback-session.desktop \
+	      $(PREFIX)/share/glib-2.0/schemas/01_i3-gnome-flashback.gschema.override
+	glib-compile-schemas $(PREFIX)/share/glib-2.0/schemas/
 
 .PHONY: install uninstall

--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ For other distributions, clone this repository and run `make install` with root 
 # Notes
 
 To understand how the files in this repo work to initialize an i3 and GNOME session, refer to this [GNOME wiki](https://wiki.gnome.org/Projects/SessionManagement/RequiredComponents) on session management.
+
+The default session for `i3-GNOME-Flashback` installs a set of configuration defaults for GSettings/dconf, e.g.:
+
+  - Desktop icon handling is disabled for GNOME Flashback, due to incompatibilities with i3, and control of the root window is instead given to `gnome-control-center`, which handles setting the user-defined wallpaper, among other things.
+
+  - Window buttons for minimize and maximize have been removed, leaving only the close button, as the former are ineffectual in i3.
+
+Setup for these configuration defaults is handled via GSettings overrides, which are described in
+further detail
+[here](https://help.gnome.org/admin/system-admin-guide/stable/dconf-custom-defaults.html.en) and
+[here](https://help.gnome.org/admin/system-admin-guide/stable/overrides.html.en).

--- a/README.md
+++ b/README.md
@@ -2,26 +2,25 @@
 
 Allows you to use i3 in a GNOME-Flashback session. Large parts of this are based on the existing [`i3-gnome`](https://github.com/lvillani/i3-gnome) project.
 
-This has been tested working on GNOME version **3.34**.
+This has been tested working on GNOME version **3.36**.
 
 # Installation
 
 For Arch users see the [AUR package](https://aur.archlinux.org/packages/i3-gnome-flashback/) for a more easy intallation.
 
 For Ubuntu (19.10), ensure prerequisites are installed:
+
 ```
 sudo apt install i3 gnome-flashback build-essential
 ```
+
 Then install i3-gnome-flashback:
+
 ```
 sudo make install
 ```
-And to prevent Nautilus from taking over the screen upon login, run this:
-```
-gsettings set org.gnome.desktop.background show-desktop-icons false
-```
 
-For other distributions, clone this repository and run `make install` with root priviledges.
+For other distributions, clone this repository and run `make install` with root privileges.
 
 # Notes
 

--- a/files/i3-gnome-flashback-session
+++ b/files/i3-gnome-flashback-session
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -z $XDG_CURRENT_DESKTOP ]; then
-    export XDG_CURRENT_DESKTOP="GNOME-Flashback:GNOME"
+    export XDG_CURRENT_DESKTOP="i3-GNOME-Flashback:GNOME-Flashback:GNOME"
 fi
 
 exec gnome-session --builtin --session=i3-gnome-flashback --disable-acceleration-check "$@"

--- a/files/i3-gnome-flashback-session.desktop
+++ b/files/i3-gnome-flashback-session.desktop
@@ -4,4 +4,4 @@ Comment=This session logs you into GNOME Flashback with i3
 Exec=i3-gnome-flashback-session
 TryExec=i3
 Type=Application
-DesktopNames=GNOME-Flashback;GNOME;
+DesktopNames=i3-GNOME-Flashback;GNOME-Flashback;GNOME;

--- a/files/i3-gnome-flashback.gschema.override
+++ b/files/i3-gnome-flashback.gschema.override
@@ -1,0 +1,6 @@
+[org.gnome.desktop.wm.preferences:i3-GNOME-Flashback]
+button-layout='appmenu:close'
+
+[org.gnome.gnome-flashback:i3-GNOME-Flashback]
+desktop=false
+root-background=true


### PR DESCRIPTION
This commit compiles fixes made by SkyyySi, in setting sane
configuration defaults for GSettings/DConf, as used by GNOME and GNOME
Flashback.

For the most part, the defaults are meant to provide a correct
experience, especially where significant functionality is broken (such
as when a pre-defined desktop background is handled as an invisible
window by i3). Other, more opinionated configuration changes are left to
users.